### PR TITLE
[#171563865] Added cached and delegated configurations to volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - "3306:3306"
         volumes:
             - ./docker/database/init.sql:/docker-entrypoint-initdb.d/init.sql
-            - ./docker/database/data:/var/lib/mysql
+            - ./docker/database/data:/var/lib/mysql:delegated
     php-fpm:
         build:
             context: ./docker/php-fpm
@@ -26,15 +26,15 @@ services:
             - PIVOTAL_TRACKER_API_KEY=${PIVOTAL_TRACKER_API_KEY}
             - PIVOTAL_TRACKER_OWNER=${PIVOTAL_TRACKER_OWNER}
         volumes:
-            - ./src/:/var/www
+            - ./src/:/var/www:cached
     nginx:
         build:
             context: ./docker/nginx
         volumes:
-            - ./src:/var/www
-            - ./docker/nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-            - ./docker/nginx/etc/nginx/sites-available:/etc/nginx/sites-available
-            - ./docker/nginx/etc/nginx/conf.d:/etc/nginx/conf.d
+            - ./src:/var/www:cached
+            - ./docker/nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf:cached
+            - ./docker/nginx/etc/nginx/sites-available:/etc/nginx/sites-available:cached
+            - ./docker/nginx/etc/nginx/conf.d:/etc/nginx/conf.d:cached
             - ./docker/logs:/var/log:delegated
         depends_on:
             - php-fpm


### PR DESCRIPTION
Before:
<img width="368" alt="Screen Shot 2020-03-01 at 8 38 08 PM" src="https://user-images.githubusercontent.com/2382439/75641212-1c6d4c80-5bfd-11ea-9942-5d3d25d9d8d1.png">

----

After:
<img width="367" alt="Screen Shot 2020-03-01 at 8 39 06 PM" src="https://user-images.githubusercontent.com/2382439/75641218-20996a00-5bfd-11ea-848c-599a73698750.png">

----

This will require you to stop and restart your containers.  This does not require a rebuild.

https://docs.docker.com/docker-for-mac/osxfs-caching/